### PR TITLE
remove forced wrapping for optional variable

### DIFF
--- a/SwiftyMenu/Classes/MenuAttributes/SwiftyMenuAttributes+ArrowStyle.swift
+++ b/SwiftyMenu/Classes/MenuAttributes/SwiftyMenuAttributes+ArrowStyle.swift
@@ -36,7 +36,7 @@ public extension SwiftyMenuAttributes {
 
         var arrowStyleValues: (isEnabled: Bool, image: UIImage?) {
             let frameworkBundle = Bundle(for: SwiftyMenu.self)
-            let defaultImage = UIImage(named: "downArrow", in: frameworkBundle, compatibleWith: nil)!
+            let defaultImage = UIImage(named: "downArrow", in: frameworkBundle, compatibleWith: nil) ?? UIImage()
 
             switch self {
             case let .value(isEnabled, image):


### PR DESCRIPTION
remove forced wrapping for optional variable
default arrow image